### PR TITLE
Add missing colon after Sniffer's password.

### DIFF
--- a/workshops/re101.html
+++ b/workshops/re101.html
@@ -123,7 +123,7 @@
 <li>OS: Lubuntu 18.04 LTS</li>
 <li>Architecture: Intel 64bit</li>
 <li>Username: Sniffer</li>
-<li>password re1012019</li>
+<li>password: re1012019</li>
 <li>IP Address: 10.10.10.112</li>
 <li>Gateway: 10.10.10.112</li>
 <li>Zip size 2.5G, Final size required 7G</li>


### PR DESCRIPTION
originally:
<li>Username: Sniffer</li>
<li>password re1012019</li>

<br>

changed:
<li>Username: Sniffer</li>
<li>password: re1012019</li>